### PR TITLE
Fix the working-dir issue

### DIFF
--- a/kwetza.py
+++ b/kwetza.py
@@ -43,9 +43,14 @@ def initialize():
 		sys.exit()
 
 	cwd = os.getcwd()
-
-	#NOW WE NEED TO DECOMPILE THE APPLICATION
-	command = ["apktool", "d", ""+cwd+"/"+sys.argv[1]]
+	
+#NOW WE SET THE TARGET FOLDER
+	outputFolderName=sys.argv[1]
+	intPoss=outputFolderName.index(".")
+	global targetFolder
+	targetFolder=cwd+"/"+outputFolderName[:intPoss]
+	#NOW WE NEED TO DECOMPILE THE APPLICATIO
+	command = ["apktool", "d", ""+cwd+"/"+sys.argv[1], "-o" ""+targetFolder+"/"]
 	p = subprocess.Popen(command, stdout=subprocess.PIPE)
 	result = p.communicate()[0]
 

--- a/kwetza.py
+++ b/kwetza.py
@@ -49,7 +49,7 @@ def initialize():
 	intPoss=outputFolderName.index(".")
 	global targetFolder
 	targetFolder=cwd+"/"+outputFolderName[:intPoss]
-	#NOW WE NEED TO DECOMPILE THE APPLICATIO
+#NOW WE NEED TO DECOMPILE THE APPLICATION
 	command = ["apktool", "d", ""+cwd+"/"+sys.argv[1], "-o" ""+targetFolder+"/"]
 	p = subprocess.Popen(command, stdout=subprocess.PIPE)
 	result = p.communicate()[0]


### PR DESCRIPTION
The pr adds the target folder to the apktool command
Using "-o (output arg.)" I've  tested it and now it works fine otherwise the code decides to use the "cwd/targetfolder /AndroidManifest.xml" to inject the permissions but ... the targetfolder isn't  in the cwd unless used the -o with apktool.. Since I'm  not too familiar with the python2's syntax so i didn't  write the code which prompts the user to specify the targetfolder .. So until someone does that we can use the default targetfolder .. which the code uses to perform some tasks :)